### PR TITLE
Update handler.py

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -16,6 +16,11 @@ FLAGGED_PHRASES = (
     'getting professional academic help from us is easy',
     'cutt.us',
     'inyurl.com/muxz7h',
+    'to cancer about a week ago',
+    'play station 5',
+    'ps5',
+    'ticket',
+    'tickets'
 )
 
 


### PR DESCRIPTION
Most groups prefer not to have tickets involved, and this is the majority of scam messages. Groups I am in have also had problems with PlayStation and the same message about losing my son to cancer or something. I would love it if you could add these flagged phrases to the bot and maybe update the description so that people know talking about tickets will be prohibited. 